### PR TITLE
Fix NullPointerException when first joining world

### DIFF
--- a/ForgeWurst MC 1.12.2/src/shared/java/net/wurstclient/forge/hacks/ItemEspHack.java
+++ b/ForgeWurst MC 1.12.2/src/shared/java/net/wurstclient/forge/hacks/ItemEspHack.java
@@ -141,7 +141,7 @@ public final class ItemEspHack extends Hack
 			if(style.getSelected().boxes)
 				GL11.glCallList(itemBox);
 			
-			if(names.isChecked())
+			if(names.isChecked() && mc.getRenderManager().options != null)
 			{
 				ItemStack stack = WItem.getItemStack(e);
 				EntityRenderer.drawNameplate(WMinecraft.getFontRenderer(),


### PR DESCRIPTION
When using this mod with the FTB Revelation modpack (1.12.2), at some point joining the server with ItemESP enabled will start always crashing the game due to a NPE in `mc.getRenderManager().options`. The only vanilla fix is to start a new single-player world, disable ItemESP, and log back in to the server. Re-enabling ItemESP after the inital load seems to work just fine. I assume that the ItemESP is called earlier than it should be, before the render manager options are loaded. I don't know if this PR is a proper fix, but it works great for me.